### PR TITLE
Transparent background for circular progress bar

### DIFF
--- a/lib/components/progress_bar/gf_progress_bar.dart
+++ b/lib/components/progress_bar/gf_progress_bar.dart
@@ -289,6 +289,7 @@ class _GFProgressBarState extends State<GFProgressBar>
                 )),
           )
         : Material(
+            color: Colors.transparent,
             child: Container(
                 width: MediaQuery.of(context).size.width,
                 child: Column(


### PR DESCRIPTION
The Circular Progress Bar is overwriting the parent element  background. This fix set background to transparent.