### PR TITLE
docs(readme): add Open-source AI tooling section + AI pillar links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - [Contributing](#contributing)
 - [Documentation](#flutter-getwidget-documentation)
 - [Resources](#resources)
+- [Open-source AI tooling](#open-source-ai-tooling)
 - [Built by](#built-by)
 - [Copyright and license](#copyright-and-license)
 - [Marketplace](https://market.getwidget.dev/)
@@ -91,12 +92,22 @@ Learn more about Flutter development with the GetWidget team:
 - [Hire Flutter developers](https://www.getwidget.dev/hire-flutter-developer/) — engagement models, rate cards, vetting
 - [Claude development services](https://www.getwidget.dev/services/claude-development/) — Claude API + Claude Code engineering
 - [AI development services](https://www.getwidget.dev/services/ai-development/) — eval-first AI builds
+- [AI agent development](https://www.getwidget.dev/services/ai-agent-development/) — agent orchestration, tool use, reliability evals
+- [AI chatbot development](https://www.getwidget.dev/services/ai-chatbot-development/) — RAG-backed chat with eval gates
 
 **Reading list**
 - [Flutter mobile app development guide](https://www.getwidget.dev/blog/flutter-mobile-app-development-guide/)
 - [Top Flutter widgets catalog](https://www.getwidget.dev/blog/top-flutter-widgets-catalog/)
 - [How much does it cost to hire a Flutter developer](https://www.getwidget.dev/blog/how-much-does-it-cost-to-hire-a-flutter-developer/)
 - [Amazing apps built with Flutter](https://www.getwidget.dev/blog/amazing-apps-built-with-flutter-framework/)
+
+## Open-source AI tooling
+
+The same team also publishes open-source AI infrastructure:
+
+- **[paiteq/ai-eval-harness](https://github.com/paiteq/ai-eval-harness)** — Ragas + promptfoo eval harness for RAG and agent systems. MIT-licensed. The harness we use internally to score Claude, OpenAI, and open-source model selection on real client corpora.
+- **Benchmarks** — quarterly dated benchmarks on RAG retrieval and agent reliability, published at [getwidget.dev/benchmarks](https://www.getwidget.dev/benchmarks/).
+- **Datasets** — public eval corpora on [huggingface.co/paiteq](https://huggingface.co/paiteq).
 
 ## Built by
 


### PR DESCRIPTION
## Summary

Two small README additions to surface the team's AI engineering work to readers landing on the OSS kit:

1. **New section: `Open-source AI tooling`** (between Resources and Built by) — points to:
   - [paiteq/ai-eval-harness](https://github.com/paiteq/ai-eval-harness) (Ragas + promptfoo eval harness, MIT)
   - [getwidget.dev/benchmarks](https://www.getwidget.dev/benchmarks/) (quarterly dated benchmarks, forward link)
   - [huggingface.co/paiteq](https://huggingface.co/paiteq) (public eval corpora, forward link)

2. **Two extra AI pillar bullets** in Resources → Pillar guides:
   - AI agent development
   - AI chatbot development

3. TOC updated to include the new section.

## Why

Phase 0 of the cross-site AI authority plan. This repo is the single biggest off-site entity anchor for the getwidget.dev / paiteq.com / hireflutterdev.com triangle (4,800★ + 23K monthly pub.dev downloads). Until now it linked to the brand sites but not to the AI engineering output — readers had no path from the OSS kit to the eval harness, benchmarks, or AI services.

The benchmarks + datasets links are intentionally stubs at this stage (Phase 1 fills them). Forward links give crawlers an early signal that those URLs are coming.

## Test plan

- [x] Diff reviewed — 1 file changed, 11 insertions
- [x] No banned vocab (per voice rules); em-dash usage matches existing style
- [x] Existing Flutter narrative untouched (intro, Why GetWidget, Features, FAQ)
- [ ] Merge to master → propagates to pub.dev on next package publish