### PR TITLE
release(7.0.2): docs-only — propagate README to pub.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [7.0.2] - 2026-05-24
+
+### 📝 Documentation
+- README: pointed the "Hire Flutter developers" pillar-guide anchor at the sister staffing brand `hireflutterdev.com` (the canonical surface for that buyer cluster).
+- README: strengthened the "Built by" entry to the commercial anchor variant `HireFlutterDev — hire dedicated Flutter developers`.
+
+No runtime code changes in this release.
+
 ## [7.0.1] - 2026-05-22
 
 ### 📝 Documentation

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: getwidget
 description: GetWidget is an open-source Flutter UI Kit with 1,000+ production-ready widgets (buttons, cards, carousels, forms, and more). Maintained since 2017 by the team at getwidget.dev.
-version: 7.0.1
+version: 7.0.2
 homepage: https://github.com/ionicfirebaseapp/getwidget
 
 environment:


### PR DESCRIPTION
## Summary

Docs-only patch release (same pattern as 7.0.1). Bumps version 7.0.1 → 7.0.2 so the README anchor changes merged in #383 propagate to pub.dev's package page.

## Why

- pub.dev mirrors the repo README on each package release
- The "Hire Flutter developers" pillar-guide anchor (now → hireflutterdev.com) needs to land on pub.dev/packages/getwidget for the SEO/entity-graph value
- No runtime changes — apps upgrading from 7.0.1 → 7.0.2 see no behavior delta

## After merge

Run `dart pub publish` from a machine with publisher auth (Navin's local). Verify the new README on https://pub.dev/packages/getwidget within 5-10 minutes.